### PR TITLE
Update the pom-imagej parent to the newly released 7.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>net.imagej</groupId>
 		<artifactId>pom-imagej</artifactId>
-		<version>5.2.5</version>
+		<version>7.0.0</version>
 		<relativePath />
 	</parent>
 


### PR DESCRIPTION
- pom-imagej 7.0.0 now sets imagej1.version to 1.49q